### PR TITLE
add render manifests to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ dirs:
 	mkdir -p output/json/ || true
 	mkdir -p log || true
 
+render:
+	rm -rf rendered/manifests/*
+	helm template --namespace default --output-dir rendered/manifests/default default charts/mibserver
+
 standard: dirs $(RFC)
 	@# Compile mibs
 

--- a/rendered/manifests/default/mibserver/templates/deployment.yaml
+++ b/rendered/manifests/default/mibserver/templates/deployment.yaml
@@ -1,0 +1,77 @@
+---
+# Source: mibserver/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: default-mibserver
+  labels:
+    helm.sh/chart: mibserver-1.14.10
+    app.kubernetes.io/name: mibserver
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "1.14.10"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "kube-score/ignore": "container-image-pull-policy"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mibserver
+      app.kubernetes.io/instance: default
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mibserver
+        app.kubernetes.io/instance: default
+    spec:
+      serviceAccountName: default-mibserver
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: mibserver
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+          image: "ghcr.io/pysnmp/mibs/container:1.14.10"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NGINX_ENTRYPOINT_QUIET_LOGS
+              value: "1"
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+            - name: http-status
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http-status
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                      app.kubernetes.io/name: mibserver
+                      app.kubernetes.io/instance: default
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/rendered/manifests/default/mibserver/templates/hpa.yaml
+++ b/rendered/manifests/default/mibserver/templates/hpa.yaml
@@ -1,0 +1,26 @@
+---
+# Source: mibserver/templates/hpa.yaml
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: default-mibserver
+  labels:
+    helm.sh/chart: mibserver-1.14.10
+    app.kubernetes.io/name: mibserver
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "1.14.10"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: default-mibserver
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/rendered/manifests/default/mibserver/templates/pdb.yaml
+++ b/rendered/manifests/default/mibserver/templates/pdb.yaml
@@ -1,0 +1,18 @@
+---
+# Source: mibserver/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: default-mibserver
+  labels:
+    helm.sh/chart: mibserver-1.14.10
+    app.kubernetes.io/name: mibserver
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "1.14.10"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minAvailable: 80%
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: mibserver
+        app.kubernetes.io/instance: default

--- a/rendered/manifests/default/mibserver/templates/service.yaml
+++ b/rendered/manifests/default/mibserver/templates/service.yaml
@@ -1,0 +1,22 @@
+---
+# Source: mibserver/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-mibserver
+  labels:
+    helm.sh/chart: mibserver-1.14.10
+    app.kubernetes.io/name: mibserver
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "1.14.10"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: mibserver
+    app.kubernetes.io/instance: default

--- a/rendered/manifests/default/mibserver/templates/serviceaccount.yaml
+++ b/rendered/manifests/default/mibserver/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: mibserver/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-mibserver
+  labels:
+    helm.sh/chart: mibserver-1.14.10
+    app.kubernetes.io/name: mibserver
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "1.14.10"
+    app.kubernetes.io/managed-by: Helm

--- a/rendered/manifests/default/mibserver/templates/tests/test-connection.yaml
+++ b/rendered/manifests/default/mibserver/templates/tests/test-connection.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mibserver/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "default-mibserver-test-connection"
+  labels:
+    helm.sh/chart: mibserver-1.14.10
+    app.kubernetes.io/name: mibserver
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "1.14.10"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+    "kube-score/ignore": "pod-probes,pod-networkpolicy"
+spec:
+  containers:
+    - name: wget
+      image: busybox:1.34.1
+      imagePullPolicy: Always
+      command: ['wget']
+      args: ['default-mibserver:80/index.csv']
+      securityContext:
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi      
+  restartPolicy: Never


### PR DESCRIPTION
This PR adds render manifests to Makefile. The reason for that is to catch possible Helm template errors during the PR.