### PR TITLE
fix: add missing import to CISCO-LWAPP-AP-MIB

### DIFF
--- a/src/vendor/cisco/CISCO-LWAPP-AP-MIB
+++ b/src/vendor/cisco/CISCO-LWAPP-AP-MIB
@@ -46,7 +46,8 @@ IMPORTS
     CLApDot11RadioSubband,
     CLApDot11RadioRole,
     CLApMode,
-    CLApNtpStatus
+    CLApNtpStatus,
+    CLDot11Band
         FROM CISCO-LWAPP-TC-MIB
     cldRegulatoryDomain
         FROM CISCO-LWAPP-DOT11-MIB


### PR DESCRIPTION
Fixes #240 